### PR TITLE
change TrustServerCert type to String to match type passed from cloudformation

### DIFF
--- a/src/main/scala/com/dwolla/sqlserver/init/ExtractRequestProperties.scala
+++ b/src/main/scala/com/dwolla/sqlserver/init/ExtractRequestProperties.scala
@@ -12,7 +12,7 @@ case class DatabaseMetadata(host: Host,
                             username: MasterDatabaseUsername,
                             password: MasterDatabasePassword,
                             secretIds: List[SecretId],
-                            trustServerCert: Boolean,
+                            trustServerCert: TrustServerCert,
                            )
 
 object DatabaseMetadata {

--- a/src/main/scala/com/dwolla/sqlserver/init/TransactorFactory.scala
+++ b/src/main/scala/com/dwolla/sqlserver/init/TransactorFactory.scala
@@ -26,7 +26,7 @@ object TransactorFactory {
 
   private def sqlserverConnectionUrl(host: Host,
                                    port: Port,
-                                   trustServerCert: Boolean): String =
-    s"jdbc:sqlserver://$host:$port;encrypt=true;trustServerCertificate=${trustServerCert}"
+                                   trustServerCert: TrustServerCert): String =
+    s"jdbc:sqlserver://$host:$port;encrypt=true;trustServerCertificate=$trustServerCert"
 
 }

--- a/src/main/scala/com/dwolla/sqlserver/init/package.scala
+++ b/src/main/scala/com/dwolla/sqlserver/init/package.scala
@@ -52,6 +52,7 @@ package object init {
 
   @newtype case class Host(value: String)
   @newtype case class Port(value: Int)
+  @newtype case class TrustServerCert(value: String)
 
   @newtype case class Username(id: SqlServerUser) {
     def value: String = id.value

--- a/src/test/scala/com/dwolla/sqlserver/init/ExtractRequestPropertiesSpec.scala
+++ b/src/test/scala/com/dwolla/sqlserver/init/ExtractRequestPropertiesSpec.scala
@@ -19,7 +19,7 @@ class ExtractRequestPropertiesSpec extends munit.FunSuite {
                  "secret1",
                  "secret2"
                ],
-               "TrustServerCert": false
+               "TrustServerCert": "false"
              }"""
 
     assertEquals(
@@ -31,7 +31,7 @@ class ExtractRequestPropertiesSpec extends munit.FunSuite {
         MasterDatabaseUsername("masterdb"),
         MasterDatabasePassword("master-pass"),
         List("secret1", "secret2").map(SecretId(_)),
-        false,
+        TrustServerCert("false"),
       ))
     )
 

--- a/src/test/scala/com/dwolla/sqlserver/init/RoundTripIntegrationTest.scala
+++ b/src/test/scala/com/dwolla/sqlserver/init/RoundTripIntegrationTest.scala
@@ -84,7 +84,8 @@ class RoundTripIntegrationTest
 
         genResources[F, SecretId]()
       }
-    } yield secrets.map(DatabaseMetadata(host, port, database, username, password, _, trustServerCert = true))
+      trustServerCert <- Gen.const(TrustServerCert("true"))
+    } yield secrets.map(DatabaseMetadata(host, port, database, username, password, _, trustServerCert))
   }
 
   /**

--- a/src/test/scala/com/dwolla/sqlserver/init/TestRunner.scala
+++ b/src/test/scala/com/dwolla/sqlserver/init/TestRunner.scala
@@ -41,7 +41,7 @@ object TestRunner extends IOApp {
             MasterDatabaseUsername("sa"),
             MasterDatabasePassword("Password123"),
             List.empty,
-            trustServerCert = true,
+            TrustServerCert("true"),
           ),
           None
         )


### PR DESCRIPTION
Cloudformation passes all the properties for custom resources as strings so the lambda was failing with: `DecodingFailure at .ResourceProperties.TrustServerCert: Got value '"false"' with wrong type, expecting 'true' or 'false'`